### PR TITLE
Initial setup for Actix authentication server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "auth-one-rust"
+version = "0.1.0"
+authors = ["chris han <chris.han@example.com>"]
+edition = "2018"
+
+[dependencies]
+actix-web = "4.0"
+actix-rt = "2.5"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # Auth-one-rust
+
+## Project Description and Purpose
+
+Auth-one-rust is an authentication server built using the Actix web framework in Rust. The purpose of this project is to provide a robust and efficient authentication server that can be easily integrated into various applications.
+
+## Setup Instructions
+
+### Dependencies
+
+To set up the project, you need to have the following dependencies installed:
+
+- Rust (https://www.rust-lang.org/tools/install)
+- Cargo (comes with Rust installation)
+
+### Running the Server
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/chris-han-nih/Auth-one-rust.git
+   cd Auth-one-rust
+   ```
+
+2. Build the project:
+   ```sh
+   cargo build
+   ```
+
+3. Run the server:
+   ```sh
+   cargo run
+   ```
+
+The server will start on `127.0.0.1:8080`.
+
+## Usage Instructions
+
+### Example Request
+
+To test the server, you can use `curl` or any HTTP client to make a request to the server:
+
+```sh
+curl http://127.0.0.1:8080/
+```
+
+You should receive a response with the text "Hello, world!".

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,16 @@
+use actix_web::{web, App, HttpServer, Responder};
+
+async fn hello() -> impl Responder {
+    "Hello, world!"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .route("/", web::get().to(hello))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}


### PR DESCRIPTION
Fixes #1

Add initial project setup for Actix-based authentication server.

* **Cargo.toml**: Add package information and dependencies for `actix-web` and `actix-rt`.
* **src/main.rs**: Add `main` function to start Actix web server and a basic route to return "Hello, world!".
* **README.md**: Add project description, purpose, setup instructions, and usage instructions with example requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chris-han-nih/Auth-one-rust/pull/2?shareId=e481759b-29b1-4e79-a60b-ce9f5381361e).